### PR TITLE
fix: hide message container by default

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,8 +43,8 @@ h1 {
 }
 
 #message-container {
+  display: none; /* hidden until show class added */
   color: #321f24;
-  display: none;
 }
 
 #message-container.show {


### PR DESCRIPTION
## Summary
- hide message container until `.show` class is applied

## Testing
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68935af120cc8324a117bea0fe80ad24